### PR TITLE
Docs: actualizar git conventions y readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Abre tu navegador y dirígete a: <http://localhost:4000>
 
 ## Cómo agregar un post
 
-Primero revisa, en este [spreadshet](https://docs.google.com/spreadsheets/d/1eXp_dkgSqAkTG6fLxqE4jqQJEKXiYJbceDeTFTN74KI/edit#gid=0), que el tema a tratar no haya sido abordado previamente. Si en efecto es un nuevo tema, por favor añádelo para que todos sepan que ya lo estás escribiendo.\
+Primero revisa, en este [notion](https://www.notion.so/bukhr/Blog-1872a9fbf389428dae20b06a8bfdbff9), que el tema a tratar no haya sido abordado previamente. Si en efecto es un nuevo tema, por favor añádelo para que todos sepan que ya lo estás escribiendo.\
 Recuerda que un post puede tener 1 o más autores, por lo que si tu tema ya está siendo desarrollado, puedes ofrecerte para colaborar en él.
 
 Para agregar un post, usa:

--- a/docs/git-conventions.md
+++ b/docs/git-conventions.md
@@ -2,6 +2,7 @@
   - [Convenciones Generales de Buk](https://gitlab.com/bukhr/buk-webapp/-/blob/master/docs/git-conventions.md)
 
 Tipos adicionales de ramas (aparte de las convenciones generales de Buk)
-|Tipo      | Ejemplo                                  | Descripción   |
-|---       | ---                                      | ---           |
-| `post`   | `post/manteniendo-la-historia-ordenada`  | Un nuevo post |
+|Tipo      | Ejemplo                                  | Descripción                |
+|---       | ---                                      | ---                        |
+| `post`   | `post/manteniendo-la-historia-ordenada`  | Un nuevo post              |
+| `docs`   | `docs/guia-estilo-ramas`                 | Mejoras a la documentación |


### PR DESCRIPTION
Se agregan a las convenciones de git el tipo "docs" para cambios que tengan que ver con la documentación.
Se actualiza el link con los temas a tratar, ahora apunta al notion.