### PR TITLE
hotfix Imagen inicial quedó antes de metadata

### DIFF
--- a/_posts/2024-01-22-2023-05-22-como-ser-el-mejor-dev-de-tu-equipo.md
+++ b/_posts/2024-01-22-2023-05-22-como-ser-el-mejor-dev-de-tu-equipo.md
@@ -1,4 +1,4 @@
-<img width="160" alt="image" src="https://github.com/bukhr/tech-blog/assets/933690/602c6d82-c0d4-462f-8865-d04e2a0d845a">---
+---
 layout: post
 title: Cómo ser el mejor dev de tu equipo
 subtitle: El secreto está en construir confianza
@@ -8,6 +8,7 @@ author: Javier Vergara
 tags: confianza desarrollo
 date: 2024-05-16 16:28 +0100
 ---
+<img width="160" alt="image" src="https://github.com/bukhr/tech-blog/assets/933690/602c6d82-c0d4-462f-8865-d04e2a0d845a">
 Quizás el título huele a _clickbait_, pero espero poder entregarte un consejo que sí te ayude en tu carrera como ingeniero de software.
 
 No sé si te pasa como a mí, que estoy un poco aburrido de tanto consejo _esotérico_ pululando por ahí: rutinas avaladas por neurólogos sobre cuál es la hora óptima de dormir o despertar, millonarios aconsejando trabajar 12 horas por 7 días a la semana, monstruosos toolsets de herramientas para tomar notas y la manera correcta de organizarlas, u otro framework “agile” de moda. 


### PR DESCRIPTION
Seguramente al editar el archivo moví la imagen al comienzo del archivo y está rompiendo.