### PR TITLE
feat: agregar nueva seccion de entrevistas

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,80 @@ Hay 2 formas de poner las etiquetas:
 ## Convenciones
   - [Convenciones de git](docs/git-conventions.md)
 
+## Cómo agregar una entrevista
+
+Para agregar una nueva entrevista al blog, sigue estos pasos:
+
+1. Crea una nueva entrevista usando:
+
+```sh
+bin/create_interview "entrevista con [nombre del entrevistado] - [rol o especialidad]"
+```
+
+Esto creará:
+- Un archivo draft en `_drafts/YYYY-MM-DD-entrevista-[nombre].md`
+- Un directorio para imágenes en `assets/img/interviews/[nombre]/`
+
+1. Modifica el Front Matter del archivo con la siguiente estructura:
+
+```yaml
+layout: post
+title: "Título de la Entrevista"
+subtitle: "Rol o descripción breve del entrevistado"
+author: "Nombre del Entrevistado"
+date: YYYY-MM-DD HH:MM:SS -0600  # se autogenera, pero puedes editarlo
+background: '/assets/img/interviews/[nombre-entrevistado].jpg'
+categories: interview
+tags: [tag1, tag2, tag3]  # usa tags relevantes como: desarrollo, liderazgo-tech, innovación, etc.
+images_path: /assets/img/interviews/[nombre-entrevistado]
+```
+
+1. Estructura el contenido de la entrevista siguiendo este formato:
+
+```markdown
+Breve introducción sobre el entrevistado y el contexto de la entrevista (1-2 párrafos)
+
+## [Pregunta 1]?
+
+[Respuesta 1]
+
+## [Pregunta 2]?
+
+[Respuesta 2]
+
+...
+```
+
+1. Agrega las imágenes relacionadas con la entrevista en:
+`/assets/img/interviews/[nombre-entrevistado]/`
+
+1. Cuando la entrevista esté lista, publícala usando:
+
+```sh
+bin/jekyll publish _drafts/entrevista-con-[nombre]-[rol].md
+```
+
+### Recomendaciones para entrevistas
+
+- **Imágenes**: Incluye una foto del entrevistado (con su permiso) y/o imágenes relevantes a los temas discutidos
+- **Estructura**: Mantén un formato pregunta-respuesta claro y consistente
+- **Extensión**: Procura que las respuestas sean concisas y enfocadas
+- **Tags**: Usa tags específicos que ayuden a categorizar el contenido de la entrevista
+- **Background**: Usa una imagen de fondo relacionada con el tema de la entrevista o el área de expertise del entrevistado
+
+### Revisión y publicación
+
+Al igual que con los posts regulares:
+
+1. Asigna un revisor que conozca el tema o área del entrevistado
+2. Asegúrate de que el entrevistado haya revisado y aprobado el contenido final
+3. Solicita la aprobación final en el canal #coord-the-weekly-commit
+
 ## Usando Jekyll
 
 ### Documentación
 
-https://jekyllrb.com/docs/home
+<https://jekyllrb.com/docs/home>
 
 ### Code Highlighting
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -12,6 +12,9 @@
           <a class="nav-link" href="{{"/" | relative_url }}" >Artículos</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="{{"/interviews" | relative_url }}">Entrevistas</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="{{ site.about_us_link }}" target="_blank" rel="noopener">Sobre Buk</a>
         </li>
         <li class="nav-item">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -28,8 +28,10 @@ layout: default
 
         {{ content }}
 
-        <!-- Home Post List -->
-        {% for post in site.posts limit : 10 %}
+        <!-- Home Post List (excluding interviews) -->
+        {% assign all_posts = site.posts %}
+        {% for post in all_posts limit : 10 %}
+        {% unless post.categories contains 'interview' %}
 
         <article class="post-preview">
           <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
@@ -55,6 +57,7 @@ layout: default
 
         <hr>
 
+        {% endunless %}
         {% endfor %}
 
         {% include tags-list.html %}

--- a/_layouts/interview.html
+++ b/_layouts/interview.html
@@ -1,0 +1,31 @@
+---
+layout: page
+title: Entrevistas
+description: Conversaciones con profesionales del mundo tech
+background: '/assets/img/interviews/interviews-bg.jpg'
+---
+
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8 col-md-10 mx-auto">
+      {% for post in site.categories.interview %}
+      <article class="post-preview">
+        <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
+          <h2 class="post-title">{{ post.title }}</h2>
+          {% if post.subtitle %}
+          <h3 class="post-subtitle">{{ post.subtitle }}</h3>
+          {% endif %}
+        </a>
+        <p class="post-meta">
+          Entrevista con {{ post.author }} 
+          el {% if post.date %}{{ post.date | date: '%B %d, %Y' }}{% endif %}
+        </p>
+        <div class="post-preview-content">
+          {{ post.excerpt }}
+        </div>
+      </article>
+      <hr>
+      {% endfor %}
+    </div>
+  </div>
+</div>

--- a/_templates/interview.md
+++ b/_templates/interview.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: %{title}
+subtitle: %{subtitle}
+author: %{author}
+date: %{date}
+background: '/assets/img/interviews/%{image_path}/background.jpg'
+categories: interview
+tags: []
+images_path: /assets/img/interviews/%{image_path}
+---
+
+Breve introducción sobre el entrevistado y el contexto de la entrevista.
+
+## ¿Cuál ha sido tu trayectoria profesional?
+
+[Respuesta]
+
+## ¿Qué te motivó a trabajar en tecnología?
+
+[Respuesta]
+
+## ¿Cuáles son los mayores desafíos que has enfrentado?
+
+[Respuesta]
+
+## ¿Qué consejo le darías a otros profesionales?
+
+[Respuesta]

--- a/bin/add_article_category.rb
+++ b/bin/add_article_category.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+require 'yaml'
+
+Dir.glob('_posts/*.md').each do |file|
+  next if file.include?('ejemplo-entrevista-tech.md')
+  
+  content = File.read(file)
+  if content.start_with?('---')
+    parts = content.split('---', 3)
+    if parts.length >= 3
+      front_matter = YAML.load(parts[1]) || {}
+      unless front_matter['categories']
+        front_matter['categories'] = 'article'
+        new_content = "---\n#{front_matter.to_yaml}---#{parts[2]}"
+        File.write(file, new_content)
+        puts "Updated #{file}"
+      end
+    end
+  end
+end

--- a/bin/create_interview
+++ b/bin/create_interview
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+
+require 'date'
+require 'fileutils'
+
+def slugify(text)
+  text.downcase
+      .gsub(/[^a-z0-9\s-]/, '')
+      .gsub(/\s+/, '-')
+end
+
+def normalize_title(title)
+  title.gsub(/\s+/, ' ')  # normalizar espacios
+       .strip
+end
+
+def validate_title(title)
+  unless title.downcase.include?('entrevista con') && title.include?('-')
+    puts "Error: El título debe tener el formato 'entrevista con [nombre] - [rol]'"
+    puts "Ejemplo: entrevista con Juan Pérez - Software Engineer"
+    puts "\nTítulo recibido: #{title}"
+    exit 1
+  end
+end
+
+def create_interview(title)
+  # Normalizar y validar el título
+  title = normalize_title(title)
+  validate_title(title)
+
+  # Extraer nombre y rol del título
+  if title =~ /entrevista con (.*?)\s*-\s*(.*)/i
+    name = $1.strip
+    role = $2.strip
+  else
+    puts "Error: No se pudo extraer el nombre y rol del título."
+    puts "Formato esperado: 'entrevista con [nombre] - [rol]'"
+    puts "Ejemplo: entrevista con Juan Pérez - Software Engineer"
+    exit 1
+  end
+
+  date = Time.now.strftime('%Y-%m-%d')
+  image_path = slugify(name)
+  
+  # Crear directorio para imágenes
+  FileUtils.mkdir_p("assets/img/interviews/#{image_path}")
+  
+  # Leer el template
+  template = File.read('_templates/interview.md')
+  
+  # Reemplazar variables en el template
+  content = template
+    .gsub('%{title}', "Entrevista con #{name}")
+    .gsub('%{subtitle}', role)
+    .gsub('%{author}', name)
+    .gsub('%{date}', Time.now.strftime('%Y-%m-%d %H:%M:%S %z'))
+    .gsub('%{image_path}', image_path)
+  
+  # Crear el archivo draft
+  filename = "_drafts/#{date}-entrevista-#{slugify(name)}.md"
+  File.write(filename, content)
+  
+  puts "✓ Creado archivo: #{filename}"
+  puts "✓ Creado directorio de imágenes: assets/img/interviews/#{image_path}"
+  puts "\nRecuerda:"
+  puts "1. Agregar la foto del entrevistado como 'background.jpg' en el directorio de imágenes"
+  puts "2. Personalizar las preguntas según el área de expertise del entrevistado"
+  puts "3. Cuando esté listo, publicar usando: bin/jekyll publish #{filename}"
+end
+
+if ARGV.empty?
+  puts "Uso: bin/create_interview \"entrevista con [nombre] - [rol]\""
+  exit 1
+end
+
+create_interview(ARGV.join(' '))

--- a/interviews/index.html
+++ b/interviews/index.html
@@ -1,0 +1,6 @@
+---
+layout: interview
+title: Entrevistas
+description: Conversaciones con profesionales del mundo tech en Buk
+background: '/assets/img/interviews/interviews-bg.jpg'
+---


### PR DESCRIPTION
## Descripción del problema

Queremos agregar una nueva seccion al Tech blog que muestre entrevistas

## Qué se hizo para resolver problema

- Se agrega un nuevo template para generar entrevistas en el Techblog
- Se crea generador (comando automatico para crear una nueva entrevista)
- Se mantiene el funcionamiento actual de los articulos tech del blog
- La nueva seccion de entrevista tiene una nueva seccion en el menu
- Se diferencian las entrevistas de los articulos por una categorizacion tipo entrevista.
- Se actualiza la documentacion para el uso de entrevista

## Screenshots
[Propuesta_nueva_seccion_entrevista.webm](https://github.com/user-attachments/assets/ddb79b87-315d-46cd-aa7a-06b26dac0d91)



## Cómo probar

* Crear una nueva entrevista con el comando `bin/create_interview "entrevista con [nombre del entrevistado] - [rol o especialidad]"`
* Modificar el archivo nuevo creado a partir del comando anterior con el directorio `_drafts`
* publicar la entrevista con el comando `bin/jekyll publish _drafts/entrevista-con-[nombre]-[rol].md`
