### PR TITLE
Chore: actualizar versión de upload-pages-artifact a v3

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -49,7 +49,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:


### PR DESCRIPTION
## El Problema

En el [blog](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) de Github, se da a conocer que se deprecó la versión anterior de las github actions

## La Solución

Se cambia la versión del artifact que estamos utilizando para hacer el deploy del Tech Blog