### PR TITLE
Chore: Ocupar una versión más estable de Ubuntu

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -56,7 +56,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## El Problema

Al intentar hacer el deploy cambiando el github action, se rompe porque `ubuntu-latest (24.04)` no está soportado

## La Solución

Se cambia la versión de Ubuntu a 22.04.