### PR TITLE
Bugfix:TECHBLOG-14 - arreglando el autor de la entrevista dentro del post

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,7 +27,11 @@ layout: default
     <div class="row">
       <div class="col-lg-8 col-md-10 mx-auto">
         <p class="post-meta">
-          Escrito por
+          {% if page.categories contains 'interview' %}
+            Entrevista con
+          {% else %}
+            Escrito por
+          {% endif %}
           {% include author_link.html %}
           el
           {% assign month = page.date | date: "%-m" | minus: 1 %}


### PR DESCRIPTION
[TECHBLOG-14](https://buk.atlassian.net/browse/TECHBLOG-14)

Ahora:
<img width="1125" alt="Captura de pantalla 2025-04-24 a la(s) 1 56 18 p m" src="https://github.com/user-attachments/assets/b5f591d3-a1b6-4740-9258-2554e02261a3" />

Antes:
<img width="1029" alt="Captura de pantalla 2025-04-24 a la(s) 1 57 00 p m" src="https://github.com/user-attachments/assets/b8707e19-b917-4cf2-8b35-1413442e5285" />



[TECHBLOG-14]: https://buk.atlassian.net/browse/TECHBLOG-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ