### PR TITLE
fix: ell texto está muy pegado a la margen en mobile

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -276,7 +276,7 @@ body {
 
   .container{
     max-width: 1200px;
-    padding: 0;
+    padding: 0 1rem;
 
     .post-meta {
       color: var(--wb-font-color-2);


### PR DESCRIPTION
Actualmente:
<img width="430" height="934" alt="Captura de pantalla 2025-07-14 a la(s) 11 37 02 a m" src="https://github.com/user-attachments/assets/7a99d2ae-748f-42ea-9c3e-606031e140a4" />

Con el cambio:
<img width="335" height="727" alt="Captura de pantalla 2025-07-14 a la(s) 11 37 42 a m" src="https://github.com/user-attachments/assets/760bae4d-9666-465a-a064-7f94bcab804c" />
