### PR TITLE
fix: corrige autor en posts antiguos de mgarcia

### DIFF
--- a/_posts/2022-04-01-agilidad-onboarding-hold my-beer.md
+++ b/_posts/2022-04-01-agilidad-onboarding-hold my-beer.md
@@ -2,7 +2,7 @@
 layout: post
 title: Agilidad + onboarding = hold my beer!
 subtitle: En octubre del 2021 entré a Buk como desarrollador de software. Aquí te cuento cómo durante las primeras semanas ¡ya aportaba al código de la plataforma!
-author: Maximiliano Garcia Roe
+author: mgarcia
 tags: [buk, metodología]
 date: 2022-04-01 09:30 -0300
 images_path: "/assets/images/2022-04-01-agilidad-onboarding-hold my-beer"

--- a/_posts/2022-05-18-migracion-directa-gimnasio.md
+++ b/_posts/2022-05-18-migracion-directa-gimnasio.md
@@ -2,7 +2,7 @@
 layout: post
 subtitle: En Buk, la plataforma está siempre en constante crecimiento y aplicando mejoras, por lo que las migraciones son una parte esencial de la aplicación.
 title: Una migración directa del gimnasio
-author: Maximiliano García Roe
+author: mgarcia
 date: 2022-05-18 10:00 -0400
 tags: [ruby, migraciones]
 background: "/assets/images/2022-05-18-migracion-directa-gimnasio/portada.jpg"

--- a/_posts/2022-07-20-superheros-contra-bugs.md
+++ b/_posts/2022-07-20-superheros-contra-bugs.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Superhéroes contra el maléfico Bug
-author: Maximiliano Garcia Roe
+author: mgarcia
 tags: desarrollo software agilidad
 images_path: "/assets/images/2022-07-20-superheroes-contra-bugs"
 background: "/assets/images/2022-07-20-superheroes-contra-bugs/portada.jpg"

--- a/_posts/2025-04-21-2025-04-21-entrevista-antonio-barbosa.md
+++ b/_posts/2025-04-21-2025-04-21-entrevista-antonio-barbosa.md
@@ -2,7 +2,7 @@
 layout: post
 title: Entrevista con Antonio Barbosa
 subtitle: Ingeniero de Software en Buk
-author: Antonio Barbosa
+author: aboneto
 date: 2025-04-21 11:23:06 -0600
 background: '/assets/img/interviews/antonio-barbosa/interviews-bg.jpg'
 categories: interview

--- a/_posts/2025-08-14-el-arte-de-revisar-prs-como-transformar-feedback-en-codigo-de-calidad-y-equipo-solido.md
+++ b/_posts/2025-08-14-el-arte-de-revisar-prs-como-transformar-feedback-en-codigo-de-calidad-y-equipo-solido.md
@@ -2,7 +2,7 @@
 layout: post
 title: 'El arte de revisar PRs: cómo transformar feedback en código de calidad y fortalecer la colaboración del equipo'
 subtitle: Más que un paso técnico, la revisión de PRs es una oportunidad para aprender, crecer y construir juntos.
-author: Rony Velásquez
+author: rvelasquez
 tags: 
    - Revisión de Código
    - Pull Request

--- a/_posts/2026-04-09-acelerar-la-ingenieria-de-producto-por-que-un-playbook-vale-mas-que-un-framework-de-moda.md
+++ b/_posts/2026-04-09-acelerar-la-ingenieria-de-producto-por-que-un-playbook-vale-mas-que-un-framework-de-moda.md
@@ -4,7 +4,7 @@ title: 'Acelerar la ingeniería de producto: Por qué un Playbook vale más que 
   de moda'
 subtitle: Menos debates, más entregas. Cómo un Playbook de estandarización transformó
   nuestra ingeniería de producto.
-author: Rony Velásquez
+author: rvelasquez
 tags:
 - Ingeniería de Producto
 - Estandarización


### PR DESCRIPTION
## Summary
Actualiza el campo `author` en posts antiguos que usaban el nombre completo del autor en lugar del identificador de usuario definido en `_authors/`.

## Posts actualizados
- `2022-07-20-superheros-contra-bugs.md` → `mgarcia`
- `2022-05-18-migracion-directa-gimnasio.md` → `mgarcia`
- `2022-04-01-agilidad-onboarding-hold my-beer.md` → `mgarcia`
- `2025-08-14-el-arte-de-revisar-prs-como-transformar-feedback-en-codigo-de-calidad-y-equipo-solido.md` → `rvelasquez`
- `2026-04-09-acelerar-la-ingenieria-de-producto-por-que-un-playbook-vale-mas-que-un-framework-de-moda.md` → `rvelasquez`
- `2025-04-21-2025-04-21-entrevista-antonio-barbosa.md` → `aboneto`

Los posts con autores que no tienen archivo en `_authors/` no fueron modificados.

## Test plan
- [ ] Verificar que los posts de `mgarcia` aparecen en `/authors/mgarcia.html`
- [ ] Verificar que los posts de `rvelasquez` aparecen en `/authors/rvelasquez.html`
- [ ] Verificar que los posts de `aboneto` aparecen en `/authors/aboneto.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)