### PR TITLE
chore: actualiza link del botón 'Trabaja con nosotros' en navbar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,7 +31,7 @@ youtube_channel: UC381JL3t0TwII2VfwwJHu8w
 spotify: 620n1EgxD8tE8OHHSG6wsL
 
 about_us_link: https://www.buk.cl/nosotros?utm_source=blog-eng&utm_medium=link&utm_campaign=outreach
-work_with_us_link: https://info.buk.cl/reclutamiento-buk-devs?utm_source=blog-eng&utm_medium=link&utm_campaign=outreach
+work_with_us_link: https://www.buk.cl/quienes-somos/engineering
 
 # Build settings
 theme: jekyll-theme-clean-blog


### PR DESCRIPTION
Actualiza el link del botón 'Trabaja con nosotros' en la navbar del tech blog.

**Cambio:** `https://info.buk.cl/reclutamiento-buk-devs` → `https://www.buk.cl/quienes-somos/engineering`