### PR TITLE
feat: agregar post sobre bundle update conservativo por defecto

### DIFF
--- a/_authors/jpacheco.md
+++ b/_authors/jpacheco.md
@@ -1,0 +1,9 @@
+---
+layout: author
+short_name: jpacheco
+title: 'Javier Omar Pacheco Moreno'
+name: Javier Omar Pacheco Moreno
+position: Software Engineer
+github_username: javieromar7
+---
+Software Engineer en Buk. Disfruto escribir herramientas que eliminan fricción del día a día del equipo y, cuando encuentro un problema repetitivo, me gusta resolverlo de raíz — idealmente en una gema open source (open-source gem) que otros puedan reutilizar.

--- a/_drafts/bundle-update-conservativo-por-defecto.md
+++ b/_drafts/bundle-update-conservativo-por-defecto.md
@@ -1,0 +1,209 @@
+---
+layout: post
+title: 'Actualizar una gema no debería mover 74 líneas del Gemfile.lock'
+subtitle: "Por qué `bundle update` arrastra más de lo que le pides, y cómo lo resolvimos con un plugin de Bundler que vuelve el modo conservativo el default del proyecto."
+author: jpacheco
+tags: [ruby, bundler, gema, open-source, dependencias]
+images_path: /assets/images/2026-08-13-bundle-update-conservativo-por-defecto
+date: 2026-08-13 10:00 -0300
+---
+
+Cualquiera que haya mantenido una aplicación Ruby on Rails medianamente grande conoce la escena. Necesitas actualizar **una** gema —digamos, `rails`— para aplicar un parche de seguridad o agarrar un bug fix. Ejecutas lo más obvio:
+
+```sh
+$ bundle update rails && git diff --stat Gemfile.lock
+ Gemfile.lock | 74 +++++++++++++++++++++++-----------------------
+```
+
+Setenta y cuatro líneas. Pediste mover una gema.
+
+Parte de ese diff **sí** es esperable. `rails` es una *metagem*: un paquete que agrupa a sus componentes (`actionview`, `activerecord`, `actionpack`, etc.), y tiene todo el sentido que se muevan juntas a la misma versión. Nadie se queja de eso.
+
+El problema es **lo otro** que aparece: dependencias transitivas (transitive dependencies) y compartidas —gemas que `rails` toca indirectamente, como `rack`, `nokogiri` o `concurrent-ruby`— que saltaron a versiones más nuevas que tu `Gemfile` permite, pero que tu cambio en `rails` **no necesitaba** y nadie revisó. En el mejor caso es ruido que ensucia el pull request. En el peor, rompe algo en producción.
+
+![Comparación entre bundle update rails y bundle update --conservative rails: en el primer caso las dependencias transitivas compartidas también se mueven]({{ page.images_path }}/alcance-del-update.svg)
+
+Este post cuenta cómo resolvimos ese problema de raíz con **[`bundler-conservative-update`](https://rubygems.org/gems/bundler-conservative-update)**, un plugin de Bundler que vuelve el `bundle update` conservativo por defecto, y cómo funciona por dentro.
+
+## Por qué pasa: `install` fija, `update` re-resuelve
+
+Para entender el diff gigante hay que mirar cómo Bundler decide qué versiones instalar.
+
+El `Gemfile` no lista versiones exactas: lista **restricciones** (constraints), como `gem "rack", "~> 2.2"`, que admiten un rango de versiones válidas. Bundler toma esas restricciones, suma las que declara cada gema a su vez, y construye un **grafo dirigido acíclico** (DAG) de dependencias. Después corre un **solver** que busca una combinación de versiones que satisfaga todo el grafo a la vez ([rubyguides lo explica en detalle](https://www.rubyguides.com/2021/04/bundler-dependency-resolution/)). Desde Bundler 2.5 ese solver es **Moll**, que resuelve desde cero de forma determinista ([anuncio oficial](https://bundler.io/blog/2023/10/23/bundler-2-5-beta-released.html)).
+
+El resultado de esa resolución se **fija** (lock) en el `Gemfile.lock`. Y ahí está la diferencia entre los dos comandos que más se confunden:
+
+- `bundle install` **respeta el lock**. Si las versiones fijadas siguen satisfaciendo el `Gemfile`, no se mueven.
+- `bundle update X` **desbloquea** `X` y toda su cadena de dependencias, **ignora** lo que el lock decía para esas gemas y **re-resuelve**, tomando para cada una la versión más nueva que el `Gemfile` permita.
+
+Ese re-resolver es el mecanismo del diff gigante. Si `actionpack` requiere `rack (>= 2.2.4, < 3.3)` y `rack` estaba fijada en una versión vieja, un `bundle update rails` desbloquea la cadena completa y sube `rack` al tope de ese rango. Nadie pidió mover `rack`.
+
+Y `rack` es un caso especialmente incómodo, porque no es solo una dependencia de `rails`: en nuestro monolito la arrastran también `rack-attack`, `rack-cors`, `rack-mini-profiler` y `opentelemetry-instrumentation-rack`. Es una dependencia **compartida**: una pieza de la que cuelga media aplicación, movida como efecto secundario de un cambio que era sobre otra cosa.
+
+## El daño: un cambio de comportamiento escondido en el PR de otra gema
+
+Esto no es una molestia estética. El equipo de Framework de Buk lo vivió con esa misma gema.
+
+Un salto de `rack` de la **2.2.18 a la 2.2.21** —un patch, legítimo y necesario, que cerraba alertas de seguridad— cambió el comportamiento del *multipart parser* y del *query parser*. Para que la aplicación siguiera comportándose igual hubo que escribir parches a mano, con sus tests, y el cambio alcanzó a cientos de clientes.
+
+Que un patch de seguridad ajuste comportamiento no es anormal; es el costo normal de mantener dependencias al día ([los advisories de Rack son públicos](https://github.com/rack/rack/security/advisories)). Lo doloroso a escala es otra cosa: que un cambio de ese calibre pueda **colarse escondido dentro del PR de otra gema**, sin que nadie lo haya pedido ni revisado deliberadamente. La diferencia entre "subimos `rack` y revisamos el diff del parser" y "subimos `rails` y `rack` vino de pasajero" es enorme cuando algo falla.
+
+En software de gran escala, cada actualización debería ser **intencional**. Por eso en Buk optamos por el modo conservativo, y de esa necesidad nace la gema.
+
+## `--conservative` ya existe, pero hay que acordarse
+
+Bundler tiene una bandera para exactamente esto:
+
+```sh
+bundle update --conservative rails
+```
+
+[`--conservative`](https://bundler.io/man/bundle-update.1.html) desbloquea **solo** las gemas que nombraste y deja todo lo demás exactamente como estaba en el lock. El diff se reduce a lo que pediste.
+
+El problema es que es **opt-in en cada invocación**. Funciona solo si cada persona —y cada script, y el CI— se acuerda de escribirlo. Y Bundler **no ofrece ninguna configuración** para volverlo el comportamiento por defecto del proyecto.
+
+El resultado es predecible: te olvidas una vez, un compañero se olvida otra, y el `Gemfile.lock` vuelve a llenarse de cambios que nadie pidió. La fricción no está en el flag; está en tener que recordarlo para siempre.
+
+## La solución: que la política viva en el `Gemfile`
+
+La idea detrás de `bundler-conservative-update` es simple: si "actualizar de forma conservativa" es una buena política para el proyecto, **declárala en el proyecto**, no en la memoria de cada persona.
+
+Al ser un [plugin de Bundler](https://bundler.io/guides/bundler_plugins.html), se instala declarándolo en el propio `Gemfile`:
+
+```ruby
+plugin "bundler-conservative-update"
+```
+
+El siguiente `bundle install` instala el plugin. Desde ahí, **cualquier** `bundle update` sobre ese proyecto —tuyo, de tus compañeros o del CI— se comporta de forma conservativa:
+
+```sh
+$ bundle update rails
+bundler-conservative-update: re-running with --conservative (only requested gems are updated; set BUNDLER_CONSERVATIVE_UPDATE_DISABLE=1 to opt out)
+  Pass --patch, --minor, --major or --all to choose a different update strategy.
+```
+
+## Cómo funciona por dentro
+
+Un plugin de Bundler puede registrar **hooks** (ganchos) que se disparan en ciertos eventos del ciclo de vida. Este registra `before-install-all`, que también corre durante un `bundle update`:
+
+```ruby
+# plugins.rb
+Bundler::Plugin.add_hook("before-install-all") do |_dependencies|
+  hook = BundlerConservativeUpdate::Hook.new(argv: ARGV, env: ENV)
+
+  next unless hook.should_inject?
+
+  # ... re-ejecutar bundle con --conservative
+end
+```
+
+El hook recibe las dependencias, pero **lo importante no está ahí**: qué tan lejos debe llegar el update vive en `ARGV`, los argumentos de la línea de comandos. Así que el plugin inspecciona `ARGV` y decide.
+
+![Flujo del plugin: en el primer pase el hook evalúa cuatro condiciones y re-ejecuta el comando con Kernel.exec; en el segundo pase declina inyectar]({{ page.images_path }}/flujo-del-plugin.svg)
+
+### La decisión
+
+Toda la lógica vive en una clase [`Hook`](https://github.com/bukhr/bundler-conservative-update/blob/main/lib/bundler_conservative_update.rb) que se instancia con `argv` y `env` inyectados —lo que la hace testeable sin un Bundler real— y responde a una sola pregunta:
+
+```ruby
+def should_inject?
+  index = update_index
+
+  return false if index.nil?
+  return false unless @argv[index] == "update"
+
+  args = @argv[(index + 1)..] || []
+
+  return false if skip_flag?(args)
+  return false unless scope?(args)
+  return false if disabled?
+
+  true
+end
+```
+
+Se rehúsa a inyectar si el subcomando no es `update` (así `bundle install`, `bundle exec` o `bundle lock` quedan fuera), si el comando ya declara una estrategia explícita (`--conservative`, `--patch`, `--minor`, `--major`, `--strict`, `--all`, `--ruby`, `--bundler`, `--source`), si no nombra nada que actualizar, o si está activo el opt-out por entorno.
+
+Encontrar el subcomando suena trivial y no lo es: hay que saltarse el valor de opciones globales como `--retry 3`, donde el `3` no es un subcomando sino el argumento del flag anterior.
+
+### Re-ejecutar sin envolver
+
+Cuando la decisión es inyectar, el plugin no llama a Bundler internamente: **reemplaza el proceso actual**.
+
+```ruby
+Kernel.exec(Gem.ruby, spec.bin_file("bundle"), *hook.conservative_argv)
+```
+
+`Kernel.exec` sustituye el proceso en el lugar, así que el stdin y la TTY se heredan, y el exit code que recibes es el del `bundle update` real, no el de un envoltorio. El nuevo `ARGV` es el original con `--conservative` insertado justo después del subcomando:
+
+```ruby
+def conservative_argv
+  new_argv = @argv.dup
+  new_argv.insert(update_index + 1, "--conservative")
+  new_argv
+end
+```
+
+### El guard de recursión que no existe
+
+Re-ejecutar el comando tiene un riesgo obvio: el hook se dispara, re-ejecuta, el hook se vuelve a disparar, y así hasta el infinito. La solución no usa ninguna variable de entorno ni marca de estado.
+
+La recursión se corta sola porque el comando re-ejecutado ya lleva `--conservative` en su propio `ARGV`, y `--conservative` es justamente una de las estrategias explícitas que hacen declinar al hook. Lo ve, se hace a un lado y deja correr el update. El guard contra la recursión y el caso "el usuario ya lo pidió" son literalmente el mismo chequeo.
+
+## Cuándo inyecta, de un vistazo
+
+| Invocación | ¿Inyecta `--conservative`? | Por qué |
+|---|---|---|
+| `bundle update rails` | sí | nombra una gema |
+| `bundle update rails --local` | sí | las flags que no cambian el alcance se conservan |
+| `bundle update --group dev` | sí | Bundler expande el grupo en las gemas a desbloquear |
+| `bundle update` (sin gemas) | no | no nombra nada; ver abajo |
+| `bundle install`, `bundle exec`, `bundle lock` | no | no es un update |
+| `bundle update --conservative rails` | no | ya fue pedido; también es el guard de recursión |
+| `bundle update --patch/--minor/--major/--strict rails` | no | estrategia explícita |
+| `bundle update --all` | no | "actualiza todo", explícito |
+| `bundle update --bundler`, `--source`, `--ruby` | no | cambian *qué* se resuelve, no nombran gemas |
+| cualquiera con `BUNDLER_CONSERVATIVE_UPDATE_DISABLE=1` | no | opt-out |
+
+### La sutileza: por qué un `bundle update` pelado no se protege
+
+Este es el detalle que más me costó pulir. Uno esperaría que un `bundle update` a secas también se volviera conservativo. Pero `--conservative` restringe la resolución **a través de la lista de gemas que se pidió desbloquear explícitamente**. Cuando esa lista viene vacía, Bundler cae en un fallback y desbloquea **todas** las dependencias directas del `Gemfile`: justo el resultado que el plugin existe para evitar.
+
+Inyectar ahí no restringiría nada y, peor, imprimiría un mensaje que promete algo que no está ocurriendo. Por eso el plugin se hace a un lado, y lo mismo vale para `--bundler`, `--source` y `--ruby`, que cambian qué se resuelve en vez de nombrar gemas.
+
+## Relación con `prefer_patch`
+
+Bundler tiene un setting relacionado que genera confusión: [`prefer_patch`](https://bundler.io/man/bundle-config.1.html) (`BUNDLE_PREFER_PATCH`), que hace que `bundle update` se comporte como `bundle update --patch`. Controlan cosas distintas:
+
+- `prefer_patch` controla el **nivel** de las actualizaciones (preferir patch por sobre minor/major), no su alcance. Las dependencias compartidas y transitivas igual pueden moverse.
+- `--conservative` controla el **alcance**: solo se desbloquea lo que nombraste.
+
+El plugin automatiza **solo** el alcance, y ambos conviven bien: como el hook inspecciona `ARGV` y no la configuración de Bundler, tener `BUNDLE_PREFER_PATCH` activo no suprime la inyección. Con los dos, `bundle update rails` mueve `rails` y sus componentes sin arrastrar la cadena compartida, y además prefiere un patch release. Pasar `--patch` explícito en la línea de comandos sí lo suprime, porque ahí el comando ya declara su propia estrategia.
+
+## Limitaciones, honestamente
+
+Ninguna herramienta es mágica, y esta tiene bordes que conviene conocer antes de adoptarla:
+
+- **`bundle update` sin gemas no está protegido**, por el fallback de arriba. Nombra las gemas que quieres, o usa `--all` para ser explícito.
+- **`bundle lock --update` no está cubierto.** Ese comando pasa por una ruta de código que nunca dispara los hooks de plugins, así que el plugin no puede verlo. Prefiere `bundle update`, y si necesitas [`bundle lock --update`](https://bundler.io/man/bundle-lock.1.html), revisa el diff a mano.
+- **`--bundler`, `--source` y `--ruby` quedan fuera**, por la misma razón.
+- **Las herramientas que resuelven el lockfile sin correr `bundle update` localmente** (Dependabot, Renovate y similares) no están cubiertas.
+- **Un clone fresco queda desprotegido hasta el primer `bundle install`**, que es lo que instala el plugin.
+
+## Opt-out cuando de verdad lo quieres
+
+No hay un opt-out permanente por proyecto, y es a propósito: si un proyecto quiere updates sin restricciones, simplemente no debería declarar el plugin. Para el caso puntual de "esta vez sí quiero que las transitivas se muevan", basta una variable de entorno:
+
+```sh
+BUNDLER_CONSERVATIVE_UPDATE_DISABLE=1 bundle update rails
+```
+
+Y para la tarea periódica de actualizar todo no hace falta ninguna variable: `--all` ya se respeta.
+
+## Cuándo vale la pena
+
+`bundler-conservative-update` no es para todos los proyectos. Brilla en **monolitos grandes**, con un `Gemfile.lock` extenso, donde un `bundle update` ingenuo genera diffs inmanejables y el riesgo de una transitiva no revisada es concreto. En proyectos chicos, con pocas gemas, la fricción que ahorra es menor.
+
+Para nosotros encaja con una idea simple: las políticas que benefician a todo el proyecto deberían vivir en el proyecto —en este caso, en el `Gemfile`— y no depender de que cada persona recuerde un flag.
+
+Si la idea te sirve, la gema está en [RubyGems](https://rubygems.org/gems/bundler-conservative-update) y el código en [GitHub](https://github.com/bukhr/bundler-conservative-update). Las contribuciones y reportes de bugs son bienvenidos.

--- a/assets/images/2026-08-13-bundle-update-conservativo-por-defecto/alcance-del-update.svg
+++ b/assets/images/2026-08-13-bundle-update-conservativo-por-defecto/alcance-del-update.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 700" width="100%" role="img" aria-label="Comparación del alcance de bundle update rails contra bundle update --conservative rails">
+  <style>
+    .t { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .title { font-size: 19px; font-weight: 700; fill: #2b3c6a; }
+    .sub { font-size: 13px; fill: #5b6785; }
+    .node { font-size: 13px; font-weight: 600; }
+    .cap { font-size: 12px; fill: #5b6785; }
+    .legend { font-size: 12.5px; fill: #3d4a68; }
+  </style>
+  <rect width="760" height="700" fill="#ffffff"/>
+
+  <!-- ============ PANEL A ============ -->
+  <text class="t title" x="24" y="34">bundle update rails</text>
+  <text class="t sub" x="24" y="56">Bundler desbloquea rails y toda su cadena: 74 líneas de diff.</text>
+
+  <!-- rails -->
+  <rect x="310" y="76" width="140" height="38" rx="8" fill="#2f4daa"/>
+  <text class="t node" x="380" y="100" text-anchor="middle" fill="#ffffff">rails</text>
+  <text class="t cap" x="466" y="100">lo que pediste mover</text>
+
+  <!-- componentes -->
+  <rect x="150" y="152" width="130" height="34" rx="8" fill="#73a0db"/>
+  <text class="t node" x="215" y="174" text-anchor="middle" fill="#ffffff">actionpack</text>
+  <rect x="315" y="152" width="130" height="34" rx="8" fill="#73a0db"/>
+  <text class="t node" x="380" y="174" text-anchor="middle" fill="#ffffff">activerecord</text>
+  <rect x="480" y="152" width="130" height="34" rx="8" fill="#73a0db"/>
+  <text class="t node" x="545" y="174" text-anchor="middle" fill="#ffffff">actionview</text>
+
+  <!-- otras gemas del Gemfile -->
+  <rect x="14" y="216" width="118" height="30" rx="8" fill="#ffffff" stroke="#9aa5bd" stroke-dasharray="4 3"/>
+  <text class="t node" x="73" y="236" text-anchor="middle" fill="#5b6785">rack-attack</text>
+  <rect x="14" y="276" width="118" height="30" rx="8" fill="#ffffff" stroke="#9aa5bd" stroke-dasharray="4 3"/>
+  <text class="t node" x="73" y="296" text-anchor="middle" fill="#5b6785">rack-cors</text>
+
+  <!-- transitivas movidas -->
+  <rect x="150" y="244" width="130" height="34" rx="8" fill="#f8b62d"/>
+  <text class="t node" x="215" y="266" text-anchor="middle" fill="#3a2d05">rack</text>
+  <rect x="315" y="244" width="130" height="34" rx="8" fill="#f8b62d"/>
+  <text class="t node" x="380" y="266" text-anchor="middle" fill="#3a2d05">nokogiri</text>
+  <rect x="480" y="244" width="130" height="34" rx="8" fill="#f8b62d"/>
+  <text class="t node" x="545" y="266" text-anchor="middle" fill="#3a2d05">concurrent-ruby</text>
+
+  <!-- flechas rails -> componentes -->
+  <g stroke="#2f4daa" stroke-width="2" fill="none">
+    <path d="M355 114 L 215 152"/>
+    <path d="M380 114 L 380 152"/>
+    <path d="M405 114 L 545 152"/>
+  </g>
+  <!-- flechas componentes -> transitivas -->
+  <g stroke="#c98a10" stroke-width="2" fill="none">
+    <path d="M215 186 L 215 244"/>
+    <path d="M380 186 L 380 244"/>
+    <path d="M545 186 L 545 244"/>
+  </g>
+  <!-- flechas otras gemas -> rack -->
+  <g stroke="#9aa5bd" stroke-width="1.5" stroke-dasharray="4 3" fill="none">
+    <path d="M132 234 L 160 244"/>
+    <path d="M132 288 L 170 278"/>
+  </g>
+
+  <text class="t cap" x="380" y="304" text-anchor="middle">tres gemas que tu cambio en rails no necesitaba, y que nadie revisó</text>
+
+  <line x1="24" y1="336" x2="736" y2="336" stroke="#e3e7f0" stroke-width="2"/>
+
+  <!-- ============ PANEL B ============ -->
+  <text class="t title" x="24" y="378">bundle update --conservative rails</text>
+  <text class="t sub" x="24" y="400">Solo rails y sus componentes se mueven. El resto queda tal cual estaba en el lock.</text>
+
+  <rect x="310" y="420" width="140" height="38" rx="8" fill="#2f4daa"/>
+  <text class="t node" x="380" y="444" text-anchor="middle" fill="#ffffff">rails</text>
+
+  <rect x="150" y="496" width="130" height="34" rx="8" fill="#73a0db"/>
+  <text class="t node" x="215" y="518" text-anchor="middle" fill="#ffffff">actionpack</text>
+  <rect x="315" y="496" width="130" height="34" rx="8" fill="#73a0db"/>
+  <text class="t node" x="380" y="518" text-anchor="middle" fill="#ffffff">activerecord</text>
+  <rect x="480" y="496" width="130" height="34" rx="8" fill="#73a0db"/>
+  <text class="t node" x="545" y="518" text-anchor="middle" fill="#ffffff">actionview</text>
+
+  <rect x="150" y="588" width="130" height="34" rx="8" fill="#f2f4f8" stroke="#c3cad9"/>
+  <text class="t node" x="215" y="610" text-anchor="middle" fill="#8a93a8">rack</text>
+  <rect x="315" y="588" width="130" height="34" rx="8" fill="#f2f4f8" stroke="#c3cad9"/>
+  <text class="t node" x="380" y="610" text-anchor="middle" fill="#8a93a8">nokogiri</text>
+  <rect x="480" y="588" width="130" height="34" rx="8" fill="#f2f4f8" stroke="#c3cad9"/>
+  <text class="t node" x="545" y="610" text-anchor="middle" fill="#8a93a8">concurrent-ruby</text>
+
+  <g stroke="#2f4daa" stroke-width="2" fill="none">
+    <path d="M355 458 L 215 496"/>
+    <path d="M380 458 L 380 496"/>
+    <path d="M405 458 L 545 496"/>
+  </g>
+  <g stroke="#c3cad9" stroke-width="2" stroke-dasharray="5 4" fill="none">
+    <path d="M215 530 L 215 588"/>
+    <path d="M380 530 L 380 588"/>
+    <path d="M545 530 L 545 588"/>
+  </g>
+
+  <text class="t cap" x="380" y="648" text-anchor="middle">siguen fijadas en la versión del Gemfile.lock: cero líneas de diff</text>
+
+  <!-- leyenda -->
+  <g transform="translate(24,668)">
+    <rect x="0" y="0" width="14" height="14" rx="3" fill="#2f4daa"/>
+    <text class="t legend" x="20" y="12">gema pedida</text>
+    <rect x="128" y="0" width="14" height="14" rx="3" fill="#73a0db"/>
+    <text class="t legend" x="148" y="12">componentes del mismo release</text>
+    <rect x="388" y="0" width="14" height="14" rx="3" fill="#f8b62d"/>
+    <text class="t legend" x="408" y="12">transitiva movida</text>
+    <rect x="546" y="0" width="14" height="14" rx="3" fill="#f2f4f8" stroke="#c3cad9"/>
+    <text class="t legend" x="566" y="12">transitiva intacta</text>
+  </g>
+</svg>

--- a/assets/images/2026-08-13-bundle-update-conservativo-por-defecto/flujo-del-plugin.svg
+++ b/assets/images/2026-08-13-bundle-update-conservativo-por-defecto/flujo-del-plugin.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 560" width="100%" role="img" aria-label="Flujo del plugin: el hook decide si inyectar conservative y re-ejecuta el comando">
+  <style>
+    .t { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    .lbl { font-size: 13.5px; font-weight: 600; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 13px; }
+    .cap { font-size: 12px; fill: #5b6785; }
+    .step { font-size: 12px; font-weight: 700; fill: #9aa5bd; letter-spacing: .08em; }
+  </style>
+  <rect width="760" height="560" fill="#ffffff"/>
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0 L10 5 L0 10 z" fill="#2f4daa"/>
+    </marker>
+    <marker id="g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0 L10 5 L0 10 z" fill="#9aa5bd"/>
+    </marker>
+  </defs>
+
+  <!-- PASE 1 -->
+  <text class="t step" x="24" y="30">PRIMER PASE</text>
+
+  <rect x="24" y="44" width="250" height="40" rx="8" fill="#eef2fb" stroke="#2f4daa"/>
+  <text class="t mono" x="149" y="69" text-anchor="middle" fill="#203b9c">bundle update rails</text>
+
+  <path d="M274 64 L 330 64" stroke="#2f4daa" stroke-width="2" marker-end="url(#a)" fill="none"/>
+
+  <rect x="338" y="44" width="230" height="40" rx="8" fill="#2f4daa"/>
+  <text class="t lbl" x="453" y="69" text-anchor="middle" fill="#ffffff">hook before-install-all</text>
+
+  <path d="M453 84 L 453 100" stroke="#2f4daa" stroke-width="2" marker-end="url(#a)" fill="none"/>
+
+  <!-- checklist -->
+  <rect x="338" y="106" width="398" height="176" rx="10" fill="#fafbfe" stroke="#d8dfee"/>
+  <text class="t cap" x="358" y="130" font-weight="700" fill="#2b3c6a">¿inyecto --conservative?</text>
+  <text class="t cap" x="358" y="156">1. ¿el subcomando es <tspan class="mono">update</tspan>?</text>
+  <text class="t cap" x="358" y="180">2. ¿no trae ya una estrategia explícita?</text>
+  <text class="t cap" x="358" y="204">3. ¿nombra gemas o un grupo?</text>
+  <text class="t cap" x="358" y="228">4. ¿no está activo el opt-out por entorno?</text>
+  <text class="t cap" x="358" y="258" font-weight="700" fill="#1f7a4d">las cuatro en sí → inyecta</text>
+
+  <path d="M330 194 L 240 194" stroke="#9aa5bd" stroke-width="2" marker-end="url(#g)" fill="none" stroke-dasharray="5 4"/>
+  <rect x="24" y="160" width="206" height="68" rx="8" fill="#f4f6fa" stroke="#c3cad9"/>
+  <text class="t cap" x="127" y="186" text-anchor="middle" font-weight="700" fill="#5b6785">alguna en no</text>
+  <text class="t cap" x="127" y="208" text-anchor="middle">se hace a un lado: el comando</text>
+  <text class="t cap" x="127" y="222" text-anchor="middle">corre tal como lo escribiste</text>
+
+  <path d="M453 282 L 453 322" stroke="#2f4daa" stroke-width="2" marker-end="url(#a)" fill="none"/>
+
+  <rect x="300" y="330" width="306" height="44" rx="8" fill="#f8b62d"/>
+  <text class="t lbl" x="453" y="350" text-anchor="middle" fill="#3a2d05">Kernel.exec</text>
+  <text class="t cap" x="453" y="366" text-anchor="middle" fill="#3a2d05">reemplaza el proceso, hereda TTY y exit code</text>
+
+  <line x1="24" y1="398" x2="736" y2="398" stroke="#e3e7f0" stroke-width="2"/>
+
+  <!-- PASE 2 -->
+  <text class="t step" x="24" y="428">SEGUNDO PASE</text>
+
+  <rect x="24" y="442" width="290" height="40" rx="8" fill="#eef2fb" stroke="#2f4daa"/>
+  <text class="t mono" x="169" y="467" text-anchor="middle" fill="#203b9c">bundle update --conservative rails</text>
+
+  <path d="M314 462 L 370 462" stroke="#2f4daa" stroke-width="2" marker-end="url(#a)" fill="none"/>
+
+  <rect x="378" y="442" width="230" height="40" rx="8" fill="#2f4daa"/>
+  <text class="t lbl" x="493" y="467" text-anchor="middle" fill="#ffffff">el hook se dispara de nuevo</text>
+
+  <text class="t cap" x="24" y="512">Ve que el comando ya trae una estrategia explícita (paso 2), declina inyectar y deja correr el update.</text>
+  <text class="t cap" x="24" y="534" font-weight="700" fill="#2b3c6a">El guard contra la recursión infinita y el caso “el usuario ya lo pidió” son el mismo chequeo.</text>
+</svg>


### PR DESCRIPTION
## Issues relacionados

Sin ticket de Jira asociado — es un post del tech blog.

## Descripción

Post que explica por qué `bundle update` desbloquea más dependencias de lo que se pide, y cómo resolvemos ese problema en Buk con un plugin de Bundler que vuelve el modo conservativo el default del proyecto.

## Qué se hizo

- **Post completo** en `_drafts/bundle-update-conservativo-por-defecto.md` con secciones:
  - Por qué pasa (cómo resuelve Bundler las dependencias)
  - El daño (caso real del cambio de comportamiento en rack)
  - La solución (cómo usar `bundler-conservative-update`)
  - Cómo funciona por dentro (hooks, decisiones, re-ejecución)
  - Limitaciones honestas

- **Dos diagramas SVG** para visualizar:
  - Alcance de `bundle update` vs. `--conservative`
  - Flujo del plugin (evaluación + re-ejecución)

- **Perfil del autor** en `_authors/jpacheco.md`

- **Todos los links externos verificados** (RubyGems, GitHub públicos, advisories públicos)

## Screenshots

No aplica — es contenido de blog.

## Cómo probar

La preview se puede hacer levantando el servidor local de Jekyll y navegando al draft.